### PR TITLE
[buteo-sync-plugin-webcal] Use notebook name in logs instead of noteb…

### DIFF
--- a/src/webcalclient.cpp
+++ b/src/webcalclient.cpp
@@ -151,14 +151,14 @@ void WebCalClient::abortSync(Sync::SyncStatus aStatus)
     }
 }
 
-void WebCalClient::succeed(unsigned int added, unsigned int deleted)
+void WebCalClient::succeed(const QString &label, unsigned int added, unsigned int deleted)
 {
     mResults = Buteo::SyncResults(QDateTime::currentDateTime().toUTC(),
                                   Buteo::SyncResults::SYNC_RESULT_SUCCESS,
                                   Buteo::SyncResults::NO_ERROR);
     if (added || deleted) {
         mResults.addTargetResults
-            (Buteo::TargetResults(mNotebookUid,
+            (Buteo::TargetResults(label.isEmpty() ? mNotebookUid : label,
                                   Buteo::ItemCounts(added, deleted, 0),
                                   Buteo::ItemCounts()));
     }
@@ -212,7 +212,7 @@ void WebCalClient::processData(const QByteArray &icsData, const QByteArray &etag
     }
 
     unsigned int added = 0, deleted = 0;
-    LOG_DEBUG("Got etag" << etag);
+    LOG_DEBUG("Got etag" << etag << "was" << mNotebookEtag);
     if (etag.isEmpty() || etag != mNotebookEtag) {
         // Make Notebook writable for the time of the modifications.
         notebook->setIsReadOnly(false);
@@ -281,5 +281,5 @@ void WebCalClient::processData(const QByteArray &icsData, const QByteArray &etag
         return;
     }
 
-    succeed(added, deleted);
+    succeed(notebook->name(), added, deleted);
 }

--- a/src/webcalclient.h
+++ b/src/webcalclient.h
@@ -64,7 +64,7 @@ private Q_SLOTS:
     void dataReceived();
 
 private:
-    void succeed(unsigned int added, unsigned int deleted);
+    void succeed(const QString &label, unsigned int added, unsigned int deleted);
     void failed(Buteo::SyncResults::MinorCode code, const QString &message);
     void processData(const QByteArray &icsData, const QByteArray &etag);
 


### PR DESCRIPTION
…ook uid. Contributes to JB#49486

In the sync log, one need to put a label for each transaction entry. I was using the notebook uid previously, in case one needs to access it programatically. But it's not necessary since the event UIDs are unique over notebooks themselves. So they are enough to track an event, without knowing its notebook uid.

Since this label is used when displaying the logs in a UI, it's actually better to use the notebook label.

@pvuorela and @chriadam what do you think ?